### PR TITLE
Task/cal 14 add config files for data

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,80 +24,19 @@ CCTs.
  ```
 pip install .
 ```
- 
 
- ## App server
+## App server
   For the web app, install the required packages.
 ```
 cd app
 npm install
 ```
 
-# Preparing Data.
+# Preparing Data
 
-Callflow currently, supports two formats, [hpctoolkit](http://hpctoolkit.org/) and [caliper](www.github.com/LLNL/caliper). Sample datasets can be found in the `data` folder. Please make sure the directory structure is as given below.
+See [instructions](https://github.com/jarusified/CallFlow/tree/v2/data/README.md).
 
-## HPCToolkit
-```
-{$CALLFLOW_PATH}/data/{hpctoolkit_dataset}
-	.../experiment.xml
-	.../experiment-001.metric-db
-	.../experiment-002.metric-db
-	.../experiment-003.metric-db
-	...
-```
-
-## Caliper	
-
-```
-{$CALLFLOW_PATH}/data/{caliper_dataset}
-	.../data/experiment.json
-
-```
-
-# Configuration file.
-CallFlow requires the user to specify how various data preprocessing operations are performed (i.e., filtering, grouping operations) using a scheme. We recommend naming the configuration file with the `.callflow.json` file extension.
-
-```
-{
-    "run_name": "{run_name}", // Name of the experiment. 
-    "save_path": "{data/run_name/.callflow}", // File path to save callflow generated files.
-    "datasets": [
-        {
-            "name": "dataset-1", // name of dataset
-            "path": "data/run_name/dataset_1}", // path to dataset 1
-            "format": "{profile_format}" // HPCToolkit|Caliper
-        },
-		{
-			"name": "dataset-1", // name of dataset
-            "path": "data/run_name/dataset_1}", // path to dataset 1
-            "format": "{profile_format}" // HPCToolkit|Caliper
-		}, 
-		...
-    ],
-    "scheme": {
-        "filter_by": "{filter_metric", // time (inc)|time
-        "filter_perc": "{filter_percentage}",
-        "group_by": "{group_metric", // name for CallGraph and module for SuperGraph.
-        "module_map": {
-            "module-1": [
-                "callsite-1",
-                "callsite-2",
-				...
-            ],
-			"module-2": [
-				...
-			],
-			...
-			"module-n": [
-				...
-			]
-
-        },
-    }
-}
-```
-
+See [data examples](https://github.com/jarusified/CallFlow/tree/v2/data)
 
 # Running the web app
 

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,80 @@
+# Datasets for testing CallFlow.
+
+All the listed datasets are provided by [Hatchet](https://github.com/LLNL/hatchet/tree/develop/hatchet/tests/data).
+
+
+## Directory Structure
+Callflow currently, supports two formats, [hpctoolkit](http://hpctoolkit.org/) and [caliper](www.github.com/LLNL/caliper). 
+
+Make sure the directory structure for each format is as shown below.
+
+### HPCToolkit
+For HPCToolkit data, make sure there is an experiment.xml file and all the [metric-db](http://hpctoolkit.org/man/hpcprof.html) files are individual files. 
+
+```
+{$CALLFLOW_PATH}/data/{hpctoolkit_dataset}
+	.../experiment.xml
+	.../thread-001.metric-db
+	.../thread-002.metric-db
+	.../thread-003.metric-db
+	...
+```
+
+### Caliper	
+For caliper data, make sure you generate using `caliper-json` format.
+
+```
+{$CALLFLOW_PATH}/data/{caliper_dataset}
+	.../data.json
+    .../
+
+```
+
+# Configuration file.
+- Once the data is in place, create a `config.callflow.json` file inside the data directory. 
+
+- `config.callflow.json` uses JSON formatting to help pre-process the datasets. 
+
+
+- The "scheme" key determines how the preprocessing operations are performed (i.e., filtering, grouping operations) using a scheme.
+
+
+```
+{
+    "run_name": "{run_name}", // Name of the experiment. 
+    "save_path": "{data/run_name/.callflow}", // File path to save callflow generated files.
+    "datasets": [
+        {
+            "name": "dataset-1", // name of dataset
+            "path": "data/run_name/dataset_1}", // path to dataset 1
+            "format": "{profile_format}" // HPCToolkit|Caliper
+        },
+		{
+			"name": "dataset-1", // name of dataset
+            "path": "data/run_name/dataset_1}", // path to dataset 1
+            "format": "{profile_format}" // HPCToolkit|Caliper
+		}, 
+		...
+    ],
+    "scheme": {
+        "filter_by": "{filter_metric", // time (inc)|time
+        "filter_perc": "{filter_percentage}",
+        "group_by": "{group_metric", // name for CallGraph and module for SuperGraph.
+        "module_map": {
+            "module-1": [
+                "callsite-1",
+                "callsite-2",
+				...
+            ],
+			"module-2": [
+				...
+			],
+			...
+			"module-n": [
+				...
+			]
+
+        },
+    }
+}
+```

--- a/data/caliper-cali/config.callflow.json
+++ b/data/caliper-cali/config.callflow.json
@@ -1,0 +1,42 @@
+{
+  "run_name": "caliper-cali",
+  "save_path": "./data/caliper-cali/.callflow",
+  "datasets": [
+    {
+      "name": "caliper-ex",
+      "path": "./data/caliper-cali/caliper-ex.json",
+      "format": "caliper_json"
+    }
+  ],
+  "scheme": {
+    "filter_by": "time (inc)",
+    "filter_perc": 0,
+    "group_by": "name",
+    "module_map": {
+      "Lulesh": ["main"],
+      "LeapFrog": ["LagrangeNodal", "LagrangeLeapFrog"],
+      "CalcForce": [
+        "CalcForceForNodes",
+        "CalcVolumeForceForElems",
+        "CalcHourglassControlForElems",
+        "CalcFBHourglassForceForElems"
+      ],
+      "CalcLagrange": [
+        "LagrangeElements",
+        "UpdateVolumesForElems",
+        "CalcLagrangeElements",
+        "CalcKinematicsForElems",
+        "CalcQForElems",
+        "CalcMonotonicQForElems",
+        "ApplyMaterialPropertiesForElems",
+        "EvalEOSForElems",
+        "CalcEnergyForElems",
+        "IntegrateStressForElems"
+      ],
+      "Timer": ["TimeIncrement"],
+      "CalcConstraint": [
+        "CalcTimeConstraintsForElems"
+      ]
+    }
+  }
+}

--- a/data/caliper-cpi-json/config.callflow.json
+++ b/data/caliper-cpi-json/config.callflow.json
@@ -1,0 +1,19 @@
+{
+    "run_name": "caliper-cpi-json",
+    "save_path": "./data/caliper-cpi-json/.callflow",
+    "datasets": [
+      {
+        "name": "caliper-ex",
+        "path": "./data/caliper-cpi-json/cpi-sample-callpathprofile.json",
+        "format": "caliper_json"
+      }
+    ],
+    "scheme": {
+      "filter_by": "time (inc)",
+      "filter_perc": 0,
+      "group_by": "name",
+      "module_map": {
+      }
+    }
+  }
+  

--- a/data/caliper-lulesh-json/config.callflow.json
+++ b/data/caliper-lulesh-json/config.callflow.json
@@ -1,0 +1,59 @@
+{
+  "run_name": "caliper-lulesh-json",
+  "save_path": "data/caliper-lulesh-json/.callflow",
+  "datasets": [
+    {
+      "name": "lulesh",
+      "path": "data/caliper-lulesh-json/lulesh-sample-annotation-profile.json",
+      "format": "caliper_json"
+    }
+  ],
+  "scheme": {
+    "filter_by": "time (inc)",
+    "filter_perc": 0,
+    "group_by": "name",
+    "module_map": {
+      "Lulesh": ["main", "lulesh.cycle"],
+      "LeapFrog": ["LagrangeNodal", "LagrangeLeapFrog"],
+      "CalcForce": [
+        "CalcForceForNodes",
+        "CalcVolumeForceForElems",
+        "CalcHourglassControlForElems",
+        "CalcFBHourglassForceForElems"
+      ],
+      "CalcLagrange": [
+        "LagrangeElements",
+        "UpdateVolumesForElems",
+        "CalcLagrangeElements",
+        "CalcKinematicsForElems",
+        "CalcQForElems",
+        "CalcMonotonicQGradientsForElems",
+        "CalcMonotonicQRegionForElems",
+        "ApplyMaterialPropertiesForElems",
+        "EvalEOSForElems",
+        "CalcEnergyForElems",
+        "CalcPressureForElems",
+        "CalcSoundSpeedForElems",
+        "IntegrateStressForElems",
+        "UpdateVolumesForElems"
+      ],
+      "Timer": ["TimeIncrement"],
+      "CalcConstraint": [
+        "CalcTimeConstraintsForElems",
+        "CalcCourantConstraintForElems",
+        "CalcHydroConstraintForElems"
+      ],
+      "NA": "Unknown",
+      "MPI": [
+        "MPI_Barrier",
+        "MPI_Reduce",
+        "MPI_Allreduce",
+        "MPI_Irecv",
+        "MPI_Isend",
+        "MPI_Wait",
+        "MPI_Waitall",
+        "MPI_Finalize"
+      ]
+    }
+  }
+}

--- a/data/gprof2dot-cpi/config.callflow.json
+++ b/data/gprof2dot-cpi/config.callflow.json
@@ -1,0 +1,20 @@
+{
+    "run_name": "gprof-cpi",
+    "save_path": "./data/gprof2dot-cpi/.callflow",
+    "datasets": [
+      {
+        "name": "calc-pi",
+        "path": "./data/gprof2dot-cpi/callgrind.dot.64042.0",
+        "format": "gprof"
+      }
+    ],
+    "scheme": {
+      "filter_by": "time (inc)",
+      "filter_perc": 0,
+      "group_by": "name",
+      "module_map": {
+        
+      }
+    }
+  }
+  

--- a/data/hpctoolkit-cpi-database/config.callflow.json
+++ b/data/hpctoolkit-cpi-database/config.callflow.json
@@ -1,0 +1,19 @@
+{
+    "run_name": "hpctoolkit-cpi-database",
+    "save_path": "./data/hpctoolkit-cpi-database/.callflow",
+    "datasets": [
+      {
+        "name": "calc-pi",
+        "path": "./data/hpctoolkit-cpi-database",
+        "format": "hpctoolkit"
+      }
+    ],
+    "scheme": {
+      "filter_by": "time (inc)",
+      "filter_perc": 0,
+      "group_by": "name",
+      "module_map": {
+      }
+    }
+  }
+  

--- a/data/hpctoolkit-threads-osu-allgather/config.callflow.json
+++ b/data/hpctoolkit-threads-osu-allgather/config.callflow.json
@@ -1,0 +1,19 @@
+{
+    "run_name": "hpctoolkit-threads-osu-allgather",
+    "save_path": "./data/hpctoolkit-threads-osu-allgather/.callflow",
+    "datasets": [
+      {
+        "name": "osu-allgather",
+        "path": "./data/hpctoolkit-threads-osu-allgather",
+        "format": "hpctoolkit"
+      }
+    ],
+    "scheme": {
+      "filter_by": "time (inc)",
+      "filter_perc": 0,
+      "group_by": "name",
+      "module_map": {
+      }
+    }
+  }
+  


### PR DESCRIPTION
Config files in place for the data from Hatchet.
Adds `README.md` to briefly explain the data. 

gprofdot-cpi and hpctoolkit-osu-allgather do not work right now. 
caliper-cpi does not work because module map is not there. 