### PR TITLE
clean-namespace: remove utils and timer from main exports

### DIFF
--- a/callflow/__init__.py
+++ b/callflow/__init__.py
@@ -16,8 +16,6 @@ __version__ = ".".join(__version_info__)
 
 # callflow.__init__.py
 from .logger import init_logger, get_logger
-from .utils import *
-from .timer import Timer
 
 from .datastructures.graphframe import GraphFrame
 from .datastructures.supergraph import SuperGraph


### PR DESCRIPTION
Clean up the namespace for the CallFlow package.